### PR TITLE
Add missing comma and fix a possible misunderstanding*

### DIFF
--- a/docs/04-connection.md
+++ b/docs/04-connection.md
@@ -9,7 +9,7 @@ This is done like:
 local transferGrid = GridPack.createGrid({
     Parent = screenGui,
 
-    Visible = true
+    Visible = true,
 
     GridSize = Vector2.new(8, 15),
     SlotAspectRatio = 1,
@@ -20,7 +20,7 @@ local transferGrid = GridPack.createGrid({
 })
 
 local transferLink = GridPack.createTransferLink({}) -- Create TransferLink
-grid:ConnectTransferLink(transferLink) -- Connect TransferLink to our first grid.
+myFirstGrid:ConnectTransferLink(transferLink) -- Connect TransferLink to our first grid.
 transferGrid:ConnectTransferLink(transferLink) -- Connect the TransferLink to our new grid.
 ```
 


### PR DESCRIPTION
Added missing comma to line 12.

Line 23 connects the TransferLink to "grid" but, since the comment next to this line specifies that we are connecting the TransferLink to our first grid, it would be better to replace "grid" with "myFirstGrid," since that is the name assigned to the starting grid on the "Basic Inventory" page, so as to avoid misunderstandings and to maintain consistency and continuity in the documentation.