### PR TITLE
Fix Grid:GetNextFreePositionForItem() not giving item rotation

### DIFF
--- a/src/ItemManager/Grid.lua
+++ b/src/ItemManager/Grid.lua
@@ -224,7 +224,7 @@ function Grid:GetNextFreePositionForItem(item: Types.ItemObject): Vector2?
 		for gridX = 0, self.GridSize.X - 1 do
 			local currentPosition = Vector2.new(gridX, gridY)
 			local insideBounds = self:IsRegionInBounds(currentPosition, item.Size, item.Rotation)
-			local collidingItems = self:GetItemsInRegion(currentPosition, item.Size, { item })
+			local collidingItems = self:GetItemsInRegion(currentPosition, item.Size, item.Rotation, { item })
 			if #collidingItems == 0 and insideBounds then
 				return currentPosition
 			end


### PR DESCRIPTION
Fixes a bug where Grid:GetNextFreePositionForItem() wasn't giving Grid:GetItemsInRegion() the item rotation.
Bug reported by: @TheSwipedSwiper in [Post 14 - GridPack devforum post](https://devforum.roblox.com/t/gridpack-create-gridtetris-style-inventories/2891897/14?u=ifrexsim)